### PR TITLE
Add p_value() function to chow_test

### DIFF
--- a/chow_test/__init__.py
+++ b/chow_test/__init__.py
@@ -23,7 +23,7 @@ def f_value(y1, x1, y2, x2):
             length: The number of n terms that the data represents
         """
         A = np.vstack([x, np.ones(len(x))]).T
-        rss = np.linalg.lstsq(A, y)[1]
+        rss = np.linalg.lstsq(A, y, rcond=None)[1]
         length = len(y)
         return (rss, length)
 

--- a/chow_test/__init__.py
+++ b/chow_test/__init__.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.stats import f
 
 def f_value(y1, x1, y2, x2):
     """This is the f_value function for the Chow Break test package
@@ -34,3 +35,17 @@ def f_value(y1, x1, y2, x2):
     chow_nom = (rss_total - (rss_1 + rss_2)) / 2
     chow_denom = (rss_1 + rss_2) / (n_1 + n_2 - 4)
     return chow_nom / chow_denom
+
+
+def p_value(y1, x1, y2, x2, **kwargs):
+    F = f_value(y1, x1, y2, x2, **kwargs)
+    if not F:
+        return 1
+    df1 = 2
+    df2 = len(x1) + len(x2) - 4
+
+    # The survival function (1-cdf) is more precise than using 1-cdf,
+    # this helps when p-values are very close to zero.
+    # -f.logsf would be another alternative to directly get -log(pval) instead.
+    p_val = f.sf(F[0], df1, df2)
+    return p_val

--- a/tests/test_analysis.ipynb
+++ b/tests/test_analysis.ipynb
@@ -135,17 +135,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/alexx/github/chow_test/tests/chow_test/__init__.py:26: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.\n",
-      "To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`.\n",
-      "  rss = np.linalg.lstsq(A, y)[1]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "f_test = chow_test.f_value(y1, x1, y2, x2)"
    ]
@@ -171,17 +161,7 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/alexx/github/chow_test/tests/chow_test/__init__.py:26: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.\n",
-      "To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`.\n",
-      "  rss = np.linalg.lstsq(A, y)[1]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "p_val = chow_test.p_value(y1, x1, y2, x2)"
    ]
@@ -202,13 +182,6 @@
    "source": [
     "print(p_val)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tests/test_analysis.ipynb
+++ b/tests/test_analysis.ipynb
@@ -3,8 +3,29 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/home/alexx/github/chow_test/tests'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "os.getcwd()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -15,24 +36,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
-       "<style>\n",
-       "    .dataframe thead tr:only-child th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: left;\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
        "    }\n",
        "\n",
        "    .dataframe tbody tr th {\n",
        "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
        "    }\n",
        "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
@@ -88,7 +109,7 @@
        "4  1931  -0.563742    1.170732"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -100,10 +121,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [],
    "source": [
     "y1 = data[data['Year'] < 1980]['LogEqPrem']\n",
@@ -114,25 +133,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/alexx/github/chow_test/tests/chow_test/__init__.py:26: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.\n",
+      "To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`.\n",
+      "  rss = np.linalg.lstsq(A, y)[1]\n"
+     ]
+    }
+   ],
    "source": [
     "f_test = chow_test.f_value(y1, x1, y2, x2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ 2.26875635]\n"
+      "[2.26875635]\n"
      ]
     }
    ],
@@ -142,10 +169,44 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/alexx/github/chow_test/tests/chow_test/__init__.py:26: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.\n",
+      "To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`.\n",
+      "  rss = np.linalg.lstsq(A, y)[1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "p_val = chow_test.p_value(y1, x1, y2, x2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.10981999859532093\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(p_val)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -166,7 +227,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi Joshua,

thanks for your package! I'm using it here, and added a few functions.

This pull request is for the p_value function, which returns a p-value instead of the F statistic.

In the second commit, I also added a parameter to the np.linalg.lstsq call (without changing the results), since that resulted in a warning when using it.

I also edited the test_analysis.ipynb (I just added two lines showing how to use the p_value function).

I have a few other extensions in use already, if you're interested. I have a wrapper function for a pd.Series that splits it into the y1, x1, y2, x2 variables, and another function that plots the -log(p-value) at each position, similar to the Manhattan plots in bioinformatics/computational biology.

Happy to hear your comments.

Cheers,

Alex